### PR TITLE
⚡ Optimize bulk enrollment audit logging

### DIFF
--- a/app/api/admin/bulk-enroll/submit/route.ts
+++ b/app/api/admin/bulk-enroll/submit/route.ts
@@ -102,16 +102,8 @@ export async function POST(request: NextRequest) {
         },
       });
 
-      // Audit log for each assignment
-      await Promise.all(
-        created.map((assignment) =>
-          auditActions.programmeEnrollmentCreated(
-            session.user.id,
-            assignment.id,
-            assignment.course.title,
-          ),
-        ),
-      );
+      // Audit log for assignments
+      await auditActions.programmeEnrollmentsCreated(session.user.id, created);
 
       return NextResponse.json({
         created: created.length,
@@ -175,16 +167,8 @@ export async function POST(request: NextRequest) {
         ),
       );
 
-      // Audit log for each enrollment
-      await Promise.all(
-        created.map((enrollment) =>
-          auditActions.programmeEnrollmentCreated(
-            session.user.id,
-            enrollment.id,
-            enrollment.course.title,
-          ),
-        ),
-      );
+      // Audit log for enrollments
+      await auditActions.programmeEnrollmentsCreated(session.user.id, created);
 
       return NextResponse.json({
         created: created.length,


### PR DESCRIPTION
Implemented batch insert optimization for audit logs in bulk enrollment.
Replaced `Promise.all(map(...))` loop with `prisma.auditLog.createMany` to eliminate N+1 query issue.
This should improve performance when enrolling large numbers of users.
Note: Benchmark verification was attempted but skipped due to environment limitations (lack of postgres/prisma setup issues), but the optimization is a standard best practice.

---
*PR created automatically by Jules for task [4554015468932421322](https://jules.google.com/task/4554015468932421322) started by @sayuru-akash*