### PR TITLE
⚡ Bolt: Parallelize dashboard stats queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-02-02 - Parallelizing Prisma Queries
 **Learning:** Dashboard endpoints in this Next.js app tend to fetch multiple independent datasets sequentially (waterfall), significantly increasing TFB (Time to First Byte).
 **Action:** Inspect `page.tsx` or `route.ts` files for sequential `await prisma` calls that share dependencies (like `userId`) and refactor them into `Promise.all`.
+
+## 2026-02-02 - Eliminate Dashboard Waterfall
+**Learning:** Found another waterfall in `app/api/admin/dashboard-stats/route.ts` where `enrollmentsByProgramme` was awaited after other stats.
+**Action:** Always check `Promise.all` blocks to ensure *all* independent queries are included, not just "most" of them.

--- a/app/api/admin/dashboard-stats/route.ts
+++ b/app/api/admin/dashboard-stats/route.ts
@@ -30,6 +30,7 @@ export async function GET() {
       totalSubmissions,
       pendingGrading,
       overdueAssignments,
+      enrollmentsByProgramme,
     ] = await Promise.all([
       // Count students
       prisma.user.count({
@@ -111,34 +112,34 @@ export async function GET() {
           },
         },
       }),
-    ]);
 
-    // Get enrollments per programme (top 5)
-    const enrollmentsByProgramme = await prisma.course.findMany({
-      where: { status: { not: "ARCHIVED" } },
-      take: 5,
-      select: {
-        id: true,
-        title: true,
-        _count: {
-          select: {
-            enrollments: {
-              where: {
-                status: "ACTIVE",
-                user: {
-                  role: "STUDENT",
+      // Get enrollments per programme (top 5)
+      prisma.course.findMany({
+        where: { status: { not: "ARCHIVED" } },
+        take: 5,
+        select: {
+          id: true,
+          title: true,
+          _count: {
+            select: {
+              enrollments: {
+                where: {
+                  status: "ACTIVE",
+                  user: {
+                    role: "STUDENT",
+                  },
                 },
               },
             },
           },
         },
-      },
-      orderBy: {
-        enrollments: {
-          _count: "desc",
+        orderBy: {
+          enrollments: {
+            _count: "desc",
+          },
         },
-      },
-    });
+      }),
+    ]);
 
     return NextResponse.json({
       stats: {


### PR DESCRIPTION
This PR optimizes the Admin Dashboard stats endpoint by moving the `enrollmentsByProgramme` query into the existing `Promise.all` block. Previously, this query ran sequentially after all other statistics were fetched, creating an unnecessary waterfall. This change allows all independent queries to execute concurrently, reducing the total request duration.

---
*PR created automatically by Jules for task [13103094533243942144](https://jules.google.com/task/13103094533243942144) started by @sayuru-akash*