### PR TITLE
🛡️ Sentinel: Fix Stored XSS in Student Submissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The API routes for creating and updating lesson resources (`/api/admin/resources`) directly stored user-provided HTML (`embedCode`, `textContent`) into the database without sanitization. This allowed Stored XSS attacks via `dangerouslySetInnerHTML` in the frontend.
 **Learning:** Even admin-only inputs must be sanitized because accounts can be compromised, and privilege escalation or CSRF could allow attackers to inject malicious scripts that target other users (students).
 **Prevention:** Always sanitize HTML input on the server side using a robust library like `isomorphic-dompurify` before storing it in the database. Use strict allow-lists for `iframe` sources.
+
+## 2024-05-22 - Stored XSS in Student Assignment Submissions
+**Vulnerability:** The student assignment submission endpoint (`POST /api/student/submissions`) accepted raw HTML in the `content` field without sanitization. This allowed students to inject malicious scripts that would execute when lecturers or admins viewed the submission (Stored XSS).
+**Learning:** Student-facing inputs that allow rich text are high-risk vectors for attacking privileged users (lecturers/admins). Input sanitization must be applied at the API boundary before storage.
+**Prevention:** Applied `sanitizeHtml` from `@/lib/sanitize` to the `content` field in the submission handler, ensuring all scripts and dangerous attributes are stripped while preserving safe formatting.

--- a/app/api/student/submissions/route.ts
+++ b/app/api/student/submissions/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { uploadToB2, deleteFromB2 } from "@/lib/b2";
 import { createAuditLog } from "@/lib/audit";
 import { isDeadlinePassed } from "@/lib/utils";
+import { sanitizeHtml } from "@/lib/sanitize";
 
 // POST /api/student/submissions - Create or update submission
 export async function POST(request: NextRequest) {
@@ -16,7 +17,8 @@ export async function POST(request: NextRequest) {
 
     const formData = await request.formData();
     const assignmentId = formData.get("assignmentId") as string;
-    const content = formData.get("content") as string | null;
+    const rawContent = formData.get("content") as string | null;
+    const content = rawContent ? sanitizeHtml(rawContent) : null;
     const files = formData.getAll("files") as File[];
 
     if (!assignmentId) {


### PR DESCRIPTION
Identified and fixed a Stored XSS vulnerability in the student assignment submission endpoint (`POST /api/student/submissions`). 

Previously, the `content` field accepted raw HTML input without sanitization, allowing students to inject malicious scripts (e.g., `<script>`, `onerror` handlers) that would execute when lecturers or admins viewed the submission.

This change imports the existing `sanitizeHtml` utility from `@/lib/sanitize` and applies it to the `content` field before storing it in the database.

**Verification:**
- Verified that `sanitizeHtml` correctly strips malicious tags and attributes while preserving safe HTML and allowed iframes (e.g., YouTube) using existing verification scripts.
- Verified that the new logic correctly handles the sanitize call in the route handler.

---
*PR created automatically by Jules for task [7540831090257180406](https://jules.google.com/task/7540831090257180406) started by @sayuru-akash*