### PR TITLE
⚡ Optimize analytics enrollment counting

### DIFF
--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -171,13 +171,14 @@ export async function GET(request: Request) {
             id: true,
             title: true,
             status: true,
-            enrollments: {
-              where: {
-                enrolledAt: dateFilter,
-                user: { role: "STUDENT" },
-              },
+            _count: {
               select: {
-                id: true,
+                enrollments: {
+                  where: {
+                    enrolledAt: dateFilter,
+                    user: { role: "STUDENT" },
+                  },
+                },
               },
             },
           },
@@ -189,7 +190,7 @@ export async function GET(request: Request) {
               id: course.id,
               title: course.title,
               status: course.status,
-              enrollments: course.enrollments.length,
+              enrollments: course._count.enrollments,
             }))
             .sort((a, b) => b.enrollments - a.enrollments)
             .slice(0, programmeId ? 1 : 10),


### PR DESCRIPTION
Replaced in-memory enrollment counting with Prisma `_count` aggregation in `app/api/admin/analytics/route.ts`.
This reduces memory usage from O(N) to O(1) for the enrollment count operation and avoids fetching unnecessary enrollment records.

Verified via manual code review due to environment limitations.

---
*PR created automatically by Jules for task [14776653683549296812](https://jules.google.com/task/14776653683549296812) started by @sayuru-akash*