### PR TITLE
⚡ Optimize module deletion with parallel file cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,5 @@
 ## 2026-02-02 - Eliminate Dashboard Waterfall
 **Learning:** Found another waterfall in `app/api/admin/dashboard-stats/route.ts` where `enrollmentsByProgramme` was awaited after other stats.
 **Action:** Always check `Promise.all` blocks to ensure *all* independent queries are included, not just "most" of them.
+
+- Optimized `app/api/admin/modules/[id]/route.ts` to use `Promise.allSettled` instead of sequential loops for R2 and B2 file deletion, reducing wait times based on benchmark.

--- a/app/api/admin/modules/[id]/route.ts
+++ b/app/api/admin/modules/[id]/route.ts
@@ -246,23 +246,23 @@ export async function DELETE(
       where: { id },
     });
 
-    // Clean up R2 files (resources)
-    for (const fileKey of r2FileKeys) {
-      try {
-        await deleteFromR2(fileKey);
-      } catch (error) {
-        console.error(`Failed to delete R2 file ${fileKey}:`, error);
-      }
-    }
-
-    // Clean up B2 files (submissions)
-    for (const fileKey of b2FileKeys) {
-      try {
-        await deleteFromB2(fileKey);
-      } catch (error) {
-        console.error(`Failed to delete B2 file ${fileKey}:`, error);
-      }
-    }
+    // Clean up R2 and B2 files in parallel
+    await Promise.allSettled([
+      ...r2FileKeys.map(async (fileKey) => {
+        try {
+          await deleteFromR2(fileKey);
+        } catch (error) {
+          console.error(`Failed to delete R2 file ${fileKey}:`, error);
+        }
+      }),
+      ...b2FileKeys.map(async (fileKey) => {
+        try {
+          await deleteFromB2(fileKey);
+        } catch (error) {
+          console.error(`Failed to delete B2 file ${fileKey}:`, error);
+        }
+      }),
+    ]);
 
     await recalculateCourseProgress(courseId).catch((error) => {
       console.error(

--- a/app/api/admin/modules/[id]/route.ts
+++ b/app/api/admin/modules/[id]/route.ts
@@ -246,23 +246,34 @@ export async function DELETE(
       where: { id },
     });
 
-    // Clean up R2 and B2 files in parallel
-    await Promise.allSettled([
-      ...r2FileKeys.map(async (fileKey) => {
-        try {
-          await deleteFromR2(fileKey);
-        } catch (error) {
-          console.error(`Failed to delete R2 file ${fileKey}:`, error);
-        }
-      }),
-      ...b2FileKeys.map(async (fileKey) => {
-        try {
-          await deleteFromB2(fileKey);
-        } catch (error) {
-          console.error(`Failed to delete B2 file ${fileKey}:`, error);
-        }
-      }),
-    ]);
+    // Clean up R2 and B2 files with bounded parallelism
+    const DELETE_CONCURRENCY = 10;
+    const deleteJobs = [
+      ...r2FileKeys.map(
+        (fileKey) => async () => {
+          try {
+            await deleteFromR2(fileKey);
+          } catch (error) {
+            console.error(`Failed to delete R2 file ${fileKey}:`, error);
+          }
+        },
+      ),
+      ...b2FileKeys.map(
+        (fileKey) => async () => {
+          try {
+            await deleteFromB2(fileKey);
+          } catch (error) {
+            console.error(`Failed to delete B2 file ${fileKey}:`, error);
+          }
+        },
+      ),
+    ];
+
+    for (let i = 0; i < deleteJobs.length; i += DELETE_CONCURRENCY) {
+      await Promise.allSettled(
+        deleteJobs.slice(i, i + DELETE_CONCURRENCY).map((job) => job()),
+      );
+    }
 
     await recalculateCourseProgress(courseId).catch((error) => {
       console.error(


### PR DESCRIPTION
💡 **What:** Changed sequential for...of loops for R2 and B2 file deletions to a single Promise.allSettled array in `app/api/admin/modules/[id]/route.ts`.
🎯 **Why:** Deleting a module with many lessons/resources sequentially takes significantly longer due to network I/O per file. Parallelizing them reduces the total wait time to approximately the duration of the slowest individual deletion.
📊 **Measured Improvement:** A standalone benchmark script (simulating network delays with 100ms for R2 and 150ms for B2 delays for 5 files each) demonstrated a time reduction from ~1254ms to ~151ms - an ~8.3x improvement in execution speed. Code verification steps (linting, typescript builds) passed successfully.

---
*PR created automatically by Jules for task [10970464645035403843](https://jules.google.com/task/10970464645035403843) started by @sayuru-akash*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved module deletion performance by running file cleanup tasks concurrently with bounded parallelism, reducing overall wait times and handling per-file errors without blocking.

* **Documentation**
  * Updated internal change log entry describing the recent deletion workflow improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->